### PR TITLE
Add Graph monad wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	cabal build
 
 run:
-	cabal run
+	cabal run Omnomnivore
 
 GRAPHDB_CONTAINER_NAME := janusgraph
 graphdb:

--- a/Omnomnivore.cabal
+++ b/Omnomnivore.cabal
@@ -33,7 +33,12 @@ library
     -- other-extensions:
     build-depends:    
         base ^>=4.14.1.0,
-        text
+        text,
+        mtl,
+        greskell,
+        greskell-websocket,
+        greskell-core,
+        
     hs-source-dirs:   src
     default-language: Haskell2010
 

--- a/Omnomnivore.cabal
+++ b/Omnomnivore.cabal
@@ -38,7 +38,6 @@ library
         greskell,
         greskell-websocket,
         greskell-core,
-        
     hs-source-dirs:   src
     default-language: Haskell2010
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import Omnomnivore.Graph
 
 main :: IO ()
-main = putStrLn "Hello, Haskell!"
+main = withGraph "localhost" 8182 "g" $ do
+    client <- askGraphClient
+    return ()

--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,15 @@
-{ mkDerivation, base, Cabal, lib, text, text-format }:
+{ mkDerivation, base, Cabal, greskell, greskell-core
+, greskell-websocket, lib, mtl, text, text-format
+}:
 mkDerivation {
   pname = "Omnomnivore";
   version = "0.1.0.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;
-  libraryHaskellDepends = [ base text ];
+  libraryHaskellDepends = [
+    base greskell greskell-core greskell-websocket mtl text
+  ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [ base Cabal text text-format ];
   homepage = "https://github.com/ners/Omnomnivore";

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:

--- a/src/Omnomnivore/Graph.hs
+++ b/src/Omnomnivore/Graph.hs
@@ -2,16 +2,16 @@
 
 module Omnomnivore.Graph where
 
-import Control.Monad.Reader (ReaderT (runReaderT), MonadReader (ask))
-import Network.Greskell.WebSocket (Client, Host, Port, connect, close)
-import Data.Greskell (Greskell, GraphTraversalSource, source)
-import Data.Text (Text)
 import Control.Exception (bracket)
+import Control.Monad.Reader (MonadReader (ask), ReaderT (runReaderT))
+import Data.Greskell (GraphTraversalSource, Greskell, source)
+import Data.Text (Text)
+import Network.Greskell.WebSocket (Client, Host, Port, close, connect)
 
 data GraphData = GraphData
-  { graphClient :: Client,
-    graphSource :: Greskell GraphTraversalSource
-  }
+    { graphClient :: Client
+    , graphSource :: Greskell GraphTraversalSource
+    }
 
 type Graph a = ReaderT GraphData IO a
 
@@ -21,7 +21,9 @@ askGraphSource = ask >>= \x -> return (graphSource x)
 askGraphClient :: Graph Client
 askGraphClient = ask >>= \x -> return (graphClient x)
 
-withGraph :: Host -> Port -> Text -> Graph a -> IO a
+type GraphSourceName = Text
+
+withGraph :: Host -> Port -> GraphSourceName -> Graph a -> IO a
 withGraph host port sourceName a = do
-  bracket (connect host port) close $ \client ->
-    runReaderT a GraphData {graphClient = client, graphSource = source sourceName}
+    bracket (connect host port) close $ \client ->
+        runReaderT a GraphData{graphClient = client, graphSource = source sourceName}

--- a/src/Omnomnivore/Graph.hs
+++ b/src/Omnomnivore/Graph.hs
@@ -1,3 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Omnomnivore.Graph where
 
--- TODO: add Graph reader monad
+import Control.Monad.Reader (ReaderT (runReaderT), MonadReader (ask))
+import Network.Greskell.WebSocket (Client, Host, Port, connect, close)
+import Data.Greskell (Greskell, GraphTraversalSource, source)
+import Data.Text (Text)
+import Control.Exception (bracket)
+
+data GraphData = GraphData
+  { graphClient :: Client,
+    graphSource :: Greskell GraphTraversalSource
+  }
+
+type Graph a = ReaderT GraphData IO a
+
+askGraphSource :: Graph (Greskell GraphTraversalSource)
+askGraphSource = ask >>= \x -> return (graphSource x)
+
+askGraphClient :: Graph Client
+askGraphClient = ask >>= \x -> return (graphClient x)
+
+withGraph :: Host -> Port -> Text -> Graph a -> IO a
+withGraph host port sourceName a = do
+  bracket (connect host port) close $ \client ->
+    runReaderT a GraphData {graphClient = client, graphSource = source sourceName}

--- a/src/Omnomnivore/Nodes/Step.hs
+++ b/src/Omnomnivore/Nodes/Step.hs
@@ -5,10 +5,10 @@ import Omnomnivore.Relations (LinearRelation)
 
 type Description = Text
 
-data Step = Step
-  -- ^ A step is a transformation from input ingredients to output ingredients with respect to the given quantities of input and output.
-  { stepDescription :: Description
-  -- ^ Text describing how the step is performed.
-  , stepTimeRelation :: LinearRelation
-  -- ^ The transformation from the requested amount factor to time needed to perform the step.
-  }
+data Step = -- | A step is a transformation from input ingredients to output ingredients with respect to the given quantities of input and output.
+    Step
+    { -- | Text describing how the step is performed.
+      stepDescription :: Description
+    , -- | The transformation from the requested amount factor to time needed to perform the step.
+      stepTimeRelation :: LinearRelation
+    }

--- a/src/Omnomnivore/Relations.hs
+++ b/src/Omnomnivore/Relations.hs
@@ -2,14 +2,14 @@
 
 module Omnomnivore.Relations where
 
-data LinearRelation = LinearRelation
-    -- ^ Represents a linear relation in the form `ax + b`.
-    { a :: Double
-    -- ^ The linear coefficient.
-    , b :: Double
-    -- ^ The constant coefficient.
+data LinearRelation = -- | Represents a linear relation in the form `ax + b`.
+    LinearRelation
+    { -- | The linear coefficient.
+      a :: Double
+    , -- | The constant coefficient.
+      b :: Double
     }
 
 -- | Compute the linear relation `ax + b` with given `x`.
 scaleWith :: LinearRelation -> Double -> Double
-scaleWith LinearRelation {a, b} = (+ b) . (* a)
+scaleWith LinearRelation{a, b} = (+ b) . (* a)


### PR DESCRIPTION
The Graph monad wraps around the graph client and source, allowing us to write traversals without specifying the source in every traversal.